### PR TITLE
Added date language options

### DIFF
--- a/src/jquery.rss.js
+++ b/src/jquery.rss.js
@@ -18,6 +18,7 @@
       tokens: {},
       outputMode: 'json',
       dateFormat: 'dddd MMM Do',
+      language: 'en',
       effect: 'show',
       offsetStart: false,
       offsetEnd: false,
@@ -251,7 +252,7 @@
 
     // If moment.js is available, use it to format the date.
     if (typeof moment !== 'undefined') {
-      this.formattedDate = moment(new Date(entry.publishedDate)).format(this.options.dateFormat);
+      this.formattedDate = moment(new Date(entry.publishedDate)).locale(this.options.language).format(this.options.dateFormat);
     } else {
       // Otherwise, if a custom formatting function is provided, use that.
       if (this.options.dateFormatFunction) {


### PR DESCRIPTION
Added option "language" on line 21. The "language" option is used on line 255.

Moments.js with locales 2.8.1+ required. Previous versions use "lang" instead of "locale" on line 255.
